### PR TITLE
Don't mix Promise.then with await in getSteamIDAsync

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -316,16 +316,18 @@ export module SteamAPIController {
       return steamID
     }
 
-    steamResolvable = resolveURL(steamResolvable)
+    const url = resolveURL(steamResolvable)
 
-    steamResolvable = await resolveVanityUrl(steamResolvable)
-      .then((sid) => sid.getSteamID64())
-      .catch(() => {
-        return steamResolvable
-      })
+    let sidString: string;
+    try {
+      const sid = await resolveVanityUrl(url)
+      sidString = sid.getSteamID64();
+    } catch (error) {
+      return steamResolvable
+    }
 
     try {
-      steamID = new SteamID(steamResolvable)
+      steamID = new SteamID(sidString)
     } catch (error) {
       throw error
     }


### PR DESCRIPTION
It's not a good practice to mix Promise.then and Promise.catch with async/await syntax. This should also make things more readable.